### PR TITLE
Install APCu stable version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   #Only 5.4 uses APC
   - if [ "`phpenv version-name`" == "5.4" ] && [ "`phpenv version-name`" != "hhvm" ]; then echo -e "extension = apc.so\napc.enabled=1\napc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   #+5.5 uses APCU
-  - if [ "`phpenv version-name`" != "5.4" ] && [ "`phpenv version-name`" != "hhvm" ]; then printf "\n"| pecl install apcu-beta && echo -e "extension = apcu.so\napc.enabled=1\napc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [ "`phpenv version-name`" != "5.4" ] && [ "`phpenv version-name`" != "hhvm" ]; then printf "\n"| pecl install apcu && echo -e "extension = apcu.so\napc.enabled=1\napc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
 
 script:
   - ./vendor/bin/phpunit --coverage-clover=coverage.clover


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
